### PR TITLE
Some Fixes for Qt 15

### DIFF
--- a/src/QHexView.cpp
+++ b/src/QHexView.cpp
@@ -23,7 +23,7 @@ m_pdata(NULL)
 {
 	setFont(QFont("Courier", 10));
 
-	m_charWidth = fontMetrics().width(QLatin1Char('9'));
+    m_charWidth = fontMetrics().horizontalAdvance(QLatin1Char('9'));
 	m_charHeight = fontMetrics().height();
 
 	m_posAddr = 0;
@@ -100,7 +100,7 @@ void QHexView::paintEvent(QPaintEvent *event)
 	int firstLineIdx = verticalScrollBar() -> value();
 
 	int lastLineIdx = firstLineIdx + areaSize.height() / m_charHeight;
-	if(lastLineIdx > m_pdata->size() / BYTES_PER_LINE)
+    if((unsigned int)lastLineIdx > m_pdata->size() / BYTES_PER_LINE)
 	{
 		lastLineIdx = m_pdata->size() / BYTES_PER_LINE;
 		if(m_pdata->size() % BYTES_PER_LINE)
@@ -408,12 +408,12 @@ std::size_t QHexView::cursorPos(const QPoint &position)
 {
 	int pos = -1;
 
-	if ((position.x() >= m_posHex) && (position.x() < (m_posHex + HEXCHARS_IN_LINE * m_charWidth)))
+    if (((std::size_t)position.x() >= m_posHex) && ((std::size_t)position.x() < (m_posHex + HEXCHARS_IN_LINE * m_charWidth)))
 	{
 		int x = (position.x() - m_posHex) / m_charWidth;
 		if ((x % 3) == 0)
 			x = (x / 3) * 2;
-		else
+        else
 			x = ((x / 3) * 2) + 1;
 
 		int firstLineIdx = verticalScrollBar() -> value();
@@ -445,7 +445,7 @@ void QHexView::setSelection(int pos)
     if (pos < 0)
         pos = 0;
 
-    if (pos >= m_selectInit)
+    if ((std::size_t)pos >= m_selectInit)
     {
         m_selectEnd = pos;
         m_selectBegin = m_selectInit;


### PR DESCRIPTION
Hello virinext (Victor Anjin),

I really liked your project, it works very well, recently I implemented it in my HakuDetector project, which is a binary detector, and for that I made a fixies of your hex editor to QT 15, for that I modified some details, check comparing the pull , you can also check how my project works, I hope you enjoy my collaboration, thank you:

List of fixed source code: 
fontMetrics().width(QLatin1Char('9')) -> Depreciated 
lastLineIdx > m_pdata->size() / BYTES_PER_LINE -> Unsigned int vs int warning
if ((position.x() >= m_posHex) && (position.x() < (m_posHex + HEXCHARS_IN_LINE * m_charWidth))) <- Unsigned int vs int warning
if (pos >= m_selectInit) <- (std::size_t)
if ((position.x() >= m_posHex) && (position.x() < (m_posHex + HEXCHARS_IN_LINE * m_charWidth))) < (std::size_t)

Regards